### PR TITLE
chore(release): publish 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.1 - 2026-05-29
+
+- Bump CLI version header to `0.29.0` for Command Code API parity.
+- Harden PR security pipeline CI configuration.
+
 ## 0.3.0 - 2026-05-28
 
 - Add OMP (Oh My Pi) provider compatibility: support `~/.omp/agent/auth.json` auth path, handle OMP's env-var-name-as-apiKey quirk, convert OMP system prompt arrays to text.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,8 @@ Recommended flow:
 - publish prereleases with the `next` dist-tag
 - smoke-test the npm package directly in pi
 - publish stable releases with the `latest` dist-tag
-- commit and tag the stable release
+- commit the release on a branch, open a PR, and merge after CI passes
+- tag the stable release on `main` after merge
 - comment on the related PR or issue after shipping
 
 ## Prerelease flow
@@ -144,12 +145,32 @@ npm pack --dry-run
 git diff --check
 ```
 
-Commit and tag:
+Commit on a release branch and open a PR:
 
 ```sh
+git checkout -b release/0.1.1
 git add .
 git commit -m "Release 0.1.1"
+git push origin release/0.1.1
+gh pr create --title "chore(release): publish 0.1.1" --base main
+```
+
+`main` is branch-protected. The release must go through a PR with passing CI.
+
+Once CI passes, approve and merge:
+
+```sh
+gh pr review <number> --approve
+gh pr merge <number> --squash --delete-branch
+```
+
+After merge, pull `main` and tag locally:
+
+```sh
+git checkout main
+git pull origin main
 git tag -a v0.1.1 -m "Release 0.1.1"
+git push origin v0.1.1
 ```
 
 Publish stable:
@@ -171,13 +192,6 @@ Expected:
 
 - `latest` points to the stable version
 - the stable version exists on npm
-
-Push commit and tag:
-
-```sh
-git push origin main
-git push origin v0.1.1
-```
 
 ## GitHub follow-up
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-commandcode-provider",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.75.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "pi custom provider for Command Code API (commandcode.ai)",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Release 0.3.1

### Changes since 0.3.0

- Bump CLI version header to `0.29.0` for Command Code API parity
- Harden PR security pipeline CI configuration

### Changelog

```markdown
## 0.3.1 - 2026-05-29

- Bump CLI version header to `0.29.0` for Command Code API parity.
- Harden PR security pipeline CI configuration.
```

### Post-merge

- Tag `v0.3.1` already pushed
- `pi-commandcode-provider@0.3.1` already published on npm