### PR TITLE
chore(release): publish 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.0 - 2026-06-02
+
 - Add retry mechanism for transient HTTP errors (429, 5xx) and stream-level errors, configurable via pi `settings.json` `retry.provider` fields (`timeoutMs`, `maxRetries`, `maxRetryDelayMs`). Supports exponential backoff with jitter and `Retry-After` header.
 
 ## 0.3.1 - 2026-05-29

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-commandcode-provider",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.75.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "pi custom provider for Command Code API (commandcode.ai)",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump package version to 0.4.0
- Move retry changes from Unreleased to 0.4.0 changelog section

## Test plan

- [x] npm test
- [x] npm run format:check
- [x] npm pack --dry-run
- [x] git diff --check