### PR TITLE
fix: resolve deprecation warning for apiKey value

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,7 +83,7 @@ export default async function (pi: ExtensionAPI) {
   pi.registerProvider("commandcode", {
     name: "Command Code",
     baseUrl: API_BASE,
-    apiKey: "COMMANDCODE_API_KEY",
+    apiKey: "$COMMANDCODE_API_KEY",
     authHeader: true,
     api: "commandcode-custom",
     streamSimple: streamCommandCode,

--- a/src/core.ts
+++ b/src/core.ts
@@ -193,10 +193,17 @@ export function createStreamCommandCode(deps: CoreDependencies) {
     const stream = deps.createStream()
 
     async function run() {
-      // OMP may pass the env-var name "COMMANDCODE_API_KEY" as the apiKey
-      // value instead of resolving it. Filter out this specific string.
+      // OMP may pass the legacy env-var name "COMMANDCODE_API_KEY" (old pi)
+      // or "$COMMANDCODE_API_KEY" (new pi) as the apiKey value instead of
+      // resolving it. Filter out these specific strings.
+      const LEGACY_API_KEY_REF = "$COMMANDCODE_API_KEY"
+      const OLD_API_KEY_REF = "COMMANDCODE_API_KEY"
       const hostKey =
-        options?.apiKey && options.apiKey !== "COMMANDCODE_API_KEY" ? options.apiKey : undefined
+        options?.apiKey &&
+        options.apiKey !== LEGACY_API_KEY_REF &&
+        options.apiKey !== OLD_API_KEY_REF
+          ? options.apiKey
+          : undefined
 
       const apiKey =
         hostKey ??


### PR DESCRIPTION
Shown on startup:
```
Deprecation warning: registerProvider("commandcode") apiKey value "COMMANDCODE_API_KEY" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "$COMMANDCODE_API_KEY" instead.
```

Support for previous setup kept to avoid a breaking change.