### PR TITLE
chore(release): publish 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
+## 0.4.2 - 2026-07-05
+
 - Fix Oh My Pi extension validation by avoiding the missing `calculateCost` export from OMP's legacy `pi-ai` shim.
+- Add a regression test that locks the local Command Code cost calculation to pi-ai's upstream `calculateCost` behavior.
+
+### Contributors
+
+- @CoderTCY — reported the Oh My Pi installation failure.
 
 ## 0.4.1 - 2026-06-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-commandcode-provider",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.75.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "pi custom provider for Command Code API (commandcode.ai)",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump package version to 0.4.2.
- Document the Oh My Pi installation hotfix from #25.
- Credit @CoderTCY for reporting #24.

## Validation
- COMMANDCODE_API_KEY=cc_test_dummy npm test
- npm run format:check
- npm audit --audit-level=moderate
- npm pack --dry-run
- git diff --check