### PR TITLE
chore(release): publish 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.3 - 2026-08-02
 
 - Allow pi to start when model discovery is unavailable. The provider now caches the last successfully fetched model catalog so previously discovered Command Code models remain selectable offline; a first offline start without a cache keeps Command Code unavailable until `/reload` succeeds.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-commandcode-provider",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.75.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "pi custom provider for Command Code API (commandcode.ai)",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- Publish `pi-commandcode-provider@0.4.3`.
- Ships the offline model-catalog cache so pi can start when Command Code model discovery is unavailable.
- Includes #27 and credits @k3-2o.

## Validation

Local release gate on `release/0.4.3`:

- `npm test` ✅
- `npm run typecheck` ✅
- `npm run format:check` ✅
- `npm audit --audit-level=moderate` ✅ (0 vulnerabilities)
- `npm pack --dry-run` ✅
- `git diff --check` ✅

## Release notes draft

- Allow pi to start when model discovery is unavailable.
- Cache the last successfully fetched model catalog under the agent directory.
- First offline start without a cache keeps Command Code unavailable until `/reload` succeeds.

### Contributors

- @k3-2o — reported that the model-list fetch blocked pi startup when offline.

## After CI

1. Merge this PR.
2. Tag `v0.4.3` on the resulting `main` commit.
3. `npm publish --tag latest --access public`
4. Create GitHub Release `v0.4.3`.
5. Comment on #27 after npm + GitHub Release are live.