### PR TITLE
fix(stream): forward thinking level and send images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Use the host-provided `pi-ai` and `pi-coding-agent` core packages instead of installing private runtime copies, including for local and out-of-store development checkouts.
+- Forward pi's thinking level to the Command Code API via `params.thinking = { type: "enabled" }` so reasoning traces are produced reliably instead of depending on upstream's own decision.
+- Stop echoing reasoning blocks from assistant history back to the API; upstream treats past reasoning as the answer to later questions and stops thinking in subsequent turns.
+- Convert pi image content blocks and tool-result image attachments into base64 image parts the `alpha/generate` API accepts, so pasted screenshots and image tool results are sent as user-role images.
 
 ## 0.4.4 - 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ For non-interactive OMP requests, use a provider-qualified model ID shown by `om
 omp -p "hello" --model commandcode/deepseek/deepseek-v4-flash
 ```
 
+## Thinking and images
+
+pi's thinking level is forwarded to the Command Code API as `params.thinking = { type: "enabled" }` whenever the selected model supports reasoning and the level is not `off`. Without this the API decides on its own whether to emit a reasoning trace, which makes traces appear and disappear depending on conversation history.
+
+Reasoning blocks from previous assistant turns are not echoed back to the API. The Command Code backend treats past reasoning as the answer to later follow-up questions and stops producing new reasoning, so the provider sends only text and tool calls from history while still showing the current turn's thinking live.
+
+Image content blocks in user messages and image attachments on tool results are converted to base64 image parts the `alpha/generate` API accepts, so pasted screenshots and image tool results are sent as user-role images.
+
 ## Model discovery and offline behavior
 
 The provider fetches the current model catalog from:

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -95,6 +95,39 @@ export function getApiKey(
   return undefined
 }
 
+/**
+ * Convert pi image content blocks ({ type: "image", data, mimeType }) into
+ * the Command Code / Anthropic-style image parts the alpha/generate API
+ * expects: { type: "image", source: { type: "base64", media_type, data } }.
+ */
+export function imageParts(message: { content?: unknown }): unknown[] {
+  const parts: unknown[] = []
+  for (const part of recordArray(message.content)) {
+    if (part.type === "image") {
+      const data = stringValue(part.data)
+      const mediaType = stringValue(part.mimeType) ?? "image/png"
+      if (data) {
+        parts.push({
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: mediaType,
+            data,
+          },
+        })
+      }
+    }
+  }
+  return parts
+}
+
+/**
+ * True when the message content carries at least one image block.
+ */
+export function hasImages(message: { content?: unknown }): boolean {
+  return recordArray(message.content).some((part) => part.type === "image")
+}
+
 export function textContent(message: { content?: unknown }): string {
   return recordArray(message.content)
     .filter((part) => part.type === "text")
@@ -216,20 +249,25 @@ export function messagesToCC(messages?: readonly MessageLike[]): unknown[] {
 
   for (const message of messages ?? []) {
     if (message.role === "user") {
-      out.push({
-        role: "user",
-        content: typeof message.content === "string" ? message.content : message.content,
-      })
+      const content = typeof message.content === "string" ? message.content : message.content
+      out.push({ role: "user", content })
+      // Preserve image blocks embedded directly in user content (e.g. pasted screenshots).
+      const images = imageParts(message)
+      if (images.length > 0) {
+        out.push({ role: "user", content: images })
+      }
     } else if (message.role === "assistant") {
       const parts: unknown[] = []
       for (const content of recordArray(message.content)) {
         if (content.type === "text") {
           parts.push({ type: "text", text: stringValue(content.text) ?? "" })
         } else if (content.type === "thinking") {
-          parts.push({
-            type: "reasoning",
-            text: stringValue(content.thinking) ?? "",
-          })
+          // Drop reasoning blocks from assistant history. Live testing against
+          // the Command Code API showed that when the conversation history
+          // contains a reasoning block, the upstream stops producing new
+          // reasoning in the next turn (it treats past reasoning as the answer
+          // to the follow-up question). Sending only text + tool calls keeps
+          // thinking enabled reliably turn after turn.
         } else if (content.type === "toolCall") {
           const toolCallId = stringValue(content.id) ?? ""
           if (!pairedToolCallIds.has(toolCallId)) continue
@@ -257,6 +295,17 @@ export function messagesToCC(messages?: readonly MessageLike[]): unknown[] {
           },
         ],
       })
+      // Tool results may carry image attachments (e.g. the read tool on an image
+      // file). The alpha/generate API only accepts images in user-role content,
+      // so surface them as a follow-up user message, mirroring the built-in
+      // openai-completions api behavior.
+      const images = imageParts(message)
+      if (images.length > 0) {
+        out.push({
+          role: "user",
+          content: [{ type: "text", text: "Attached image(s) from tool result:" }, ...images],
+        })
+      }
     }
   }
   return out

--- a/src/core.ts
+++ b/src/core.ts
@@ -448,6 +448,12 @@ export function createStreamCommandCode(deps: CoreDependencies) {
             max_tokens: generateMaxTokens(model, options),
             temperature: 0.3,
             stream: true,
+            // pi thinking level → upstream thinking toggle. Without this the
+            // API decides on its own and deepseek traces appear/disappear
+            // depending on conversation history.
+            ...(options?.reasoning && options.reasoning !== "off"
+              ? { thinking: { type: "enabled" } }
+              : {}),
           },
           threadId,
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,11 @@ export interface StreamOptions {
   signal?: AbortSignal
   headers?: Record<string, string>
   maxTokens?: number
+  /**
+   * pi thinking level ("off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max").
+   * Undefined/"off" means thinking is disabled; any other value enables it.
+   */
+  reasoning?: string
   onPayload?: (payload: unknown, model: ModelLike) => unknown | Promise<unknown>
   onResponse?: (response: ProviderResponseInfo, model: ModelLike) => void | Promise<void>
   /**

--- a/tests/test-pure-functions.ts
+++ b/tests/test-pure-functions.ts
@@ -13,6 +13,7 @@ import {
   getApiKey,
   getEnvironmentInfo,
   mapFinishReason,
+  imageParts,
   messagesToCC,
   parseStreamEventLine,
   projectSlugFromPath,
@@ -244,8 +245,11 @@ describe("messagesToCC()", () => {
 
     assert.equal(objectAt(result, ["0", "role"]), "user")
     assert.equal(objectAt(result, ["1", "role"]), "assistant")
-    assert.equal(objectAt(result, ["1", "content", "0", "type"]), "reasoning")
-    assert.equal(objectAt(result, ["1", "content", "2", "type"]), "tool-call")
+    // Reasoning blocks are dropped from assistant history so the upstream does
+    // not stop thinking in later turns (see src/converters.ts).
+    assert.equal(objectAt(result, ["1", "content", "0", "type"]), "text")
+    assert.equal(objectAt(result, ["1", "content", "1", "type"]), "tool-call")
+    assert.equal(objectAt(result, ["1", "content", "2"]), undefined)
     assert.equal(objectAt(result, ["2", "role"]), "tool")
     assert.equal(objectAt(result, ["2", "content", "0", "output", "value"]), "hello\nworld")
   })
@@ -274,6 +278,63 @@ describe("messagesToCC()", () => {
 
   it("handles empty conversations", () => {
     assert.deepEqual(messagesToCC([]), [])
+  })
+
+  it("converts image blocks in user messages to base64 image parts", () => {
+    const result = messagesToCC([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look at this" },
+          { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+        ],
+      },
+    ])
+    assert.equal(objectAt(result, ["0", "role"]), "user")
+    assert.equal(objectAt(result, ["1", "role"]), "user")
+    assert.deepEqual(objectAt(result, ["1", "content", "0"]), {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+    })
+  })
+
+  it("surfaces images from tool results as follow-up user messages", () => {
+    const result = messagesToCC([
+      { role: "user", content: "read image" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "c1",
+            name: "read",
+            arguments: { path: "x.png" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: "read",
+        content: [
+          { type: "text", text: "here" },
+          { type: "image", data: "aW1n", mimeType: "image/png" },
+        ],
+      },
+    ])
+    const followUp = [...result]
+      .reverse()
+      .find(
+        (m) =>
+          (m as { role?: string }).role === "user" &&
+          Array.isArray((m as { content?: unknown }).content),
+      ) as
+      | { role: string; content: Array<{ type?: string; source?: { type?: string } }> }
+      | undefined
+    assert.ok(followUp, "expected follow-up user message")
+    assert.equal(followUp.content[0]?.type, "text")
+    assert.equal(followUp.content[1]?.type, "image")
+    assert.equal(followUp.content[1]?.source?.type, "base64")
   })
 })
 

--- a/tests/test-stream.ts
+++ b/tests/test-stream.ts
@@ -226,6 +226,38 @@ describe("streamCommandCode — successful streams", () => {
     assert.ok(server.responseClosedBeforeEnd(), "client should cancel the still-open response body")
   })
 
+  it("sends thinking enabled when reasoning is set", async () => {
+    server.mockResponse({
+      type: "success",
+      events: [
+        JSON.stringify({ type: "reasoning-start" }),
+        JSON.stringify({ type: "reasoning-delta", text: "think" }),
+        JSON.stringify({ type: "reasoning-end" }),
+        JSON.stringify({ type: "finish", finishReason: "stop" }),
+      ],
+    })
+    const { streamCommandCode } = createTestDeps({ apiBase: server.baseUrl() })
+    await collectEvents(
+      streamCommandCode(makeModel(), makeContext(), {
+        apiKey: "mock-key",
+        reasoning: "high",
+      }),
+    )
+    const body = server.lastRequestBody() as { params?: Record<string, unknown> }
+    assert.deepEqual(body.params?.thinking, { type: "enabled" })
+  })
+
+  it("omits thinking when reasoning is off or unset", async () => {
+    server.mockResponse({
+      type: "success",
+      events: [JSON.stringify({ type: "finish", finishReason: "stop" })],
+    })
+    const { streamCommandCode } = createTestDeps({ apiBase: server.baseUrl() })
+    await collectEvents(streamCommandCode(makeModel(), makeContext(), { apiKey: "mock-key" }))
+    const body = server.lastRequestBody() as { params?: Record<string, unknown> }
+    assert.equal(body.params?.thinking, undefined)
+  })
+
   it("emits reasoning and tool-call blocks in order", async () => {
     server.mockResponse({
       type: "success",


### PR DESCRIPTION
## Problem

Two separate issues made the provider unreliable for reasoning models:

1. **Thinking traces disappear mid-conversation.** The provider's payload only sent `temperature`, so the Command Code API decided on its own whether to emit a reasoning trace. Live testing showed DeepSeek V4 Flash produced a trace on the first turn, then silently stopped once tool results and history accumulated — even though pi's thinking level stayed `high`.

2. **Image content was dropped.** pi image blocks (pasted screenshots) and image attachments on tool results were silently discarded, so vision models never received the images.

## Root cause

`createStreamCommandCode` in `src/core.ts` built the `/alpha/generate` payload without reading pi's `options.reasoning` (the thinking level). pi does pass `reasoning` in stream options, but the provider ignored it.

Live experiments against the real API (same model, same `thinking: {type:"enabled"}`) revealed the upstream behavior that caused the intermittent traces:

| scenario | reasoning-delta count |
|---|---|
| fresh conversation | 54 |
| history contains a reasoning block | **1** (thinking effectively stopped) |
| history contains only tool-call/tool-result | 36 (still thinking) |

The upstream treats past reasoning as the answer to later questions and stops thinking. So echoing reasoning blocks back in assistant history is actively harmful.

## Changes

- **`src/core.ts`** — forward pi's thinking level: when `options.reasoning` is set and not `"off"`, send `params.thinking = { type: "enabled" }`.
- **`src/converters.ts`** — drop reasoning blocks from assistant history sent to the API (still stream the current turn's thinking live). Also convert pi image blocks and tool-result image attachments to the base64 image parts the `alpha/generate` API accepts, surfaced as user-role content (mirrors the built-in `openai-completions` behavior).
- **`src/types.ts`** — add `reasoning?: string` to `StreamOptions`.
- **`tests/test-stream.ts`** — payload tests: `thinking` present when `reasoning` set, absent when off/unset.
- **`tests/test-pure-functions.ts`** — update `messagesToCC` expectations (reasoning dropped), add image conversion tests.
- **`README.md` / `CHANGELOG.md`** — document the thinking/image behavior.

## Verification

- `npm run typecheck` — clean
- `npm test` — 89 pass, 0 fail (unit + integration with the mock Command Code server)
- `npm run format:check` — clean
- Live API check with the real key: `reasoning: "high"` → payload contains `thinking: {type:"enabled"}` → response streams `thinking_start` / `thinking_delta` (22 deltas) / `thinking_end` with `content: [thinking, text]`.

Note: `tests/test-pi-local.mjs` fails locally with `No models available` vs expected `No models matching` — this also fails on a clean checkout without my changes; it is an environment/pi-version mismatch unrelated to this PR.
