### PR TITLE
chore(release): publish 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Unreleased
 
+## 0.5.1 - 2026-08-11
+
 - Add model-specific image input capabilities from the `command-code@1.15.1` catalog and forward user and tool-result images using the current Command Code wire format.
 - Update the Command Code client version header to `1.15.1`.
+
+### Contributors
+
+- @DiyarD — reported missing vision support for GPT-5.6 Luna, Muse Spark 1.2, and other vision-capable models.
 
 ## 0.5.0 - 2026-08-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-commandcode-provider",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "25.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-commandcode-provider",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "pi custom provider for Command Code API (commandcode.ai)",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- release `pi-commandcode-provider@0.5.1`
- document model-specific vision input support shipped by #43
- credit @DiyarD for reporting #42

Includes #43 and closes #42 when published.

## Verification

- `npm test`
- `npm run typecheck`
- `npm run format:check`
- `npm audit --audit-level=moderate`
- `npm pack --dry-run`
- `git diff --check`

All gates passed. The optional OMP compatibility smoke test was skipped because `omp` is not installed on PATH.
