### PR TITLE
fix(core): register custom api under non-reserved name for omp 17.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add optional zero-data-retention headers through `COMMANDCODE_ZDR=1`.
 - Refresh GPT-5.6 Terra and Luna display prices after their temporary 50% promotion ended, and display the current DeepSeek V4 off-peak rates for its time-dependent pricing.
 - Add isolated live E2E profiles for separate Go-plan and Provider-API credentials, including an explicit selected-transport assertion and packed-package validation.
+- Fix extension load failure on newer pi hosts that reject registering a custom API under a built-in name (`openai-completions`); register under `commandcode-custom` instead and restore the real wire API before native compat dispatch.
 
 ## 0.5.1 - 2026-08-11
 

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import { getConfiguredApiKey } from "./src/api-key.ts"
 import { createStreamCommandCode } from "./src/core.ts"
 import { calculateCommandCodeCost } from "./src/cost.ts"
 import {
+  apiForModelId,
   baseUrlForModel,
   DEFAULT_MODELS_URL,
   DEFAULT_PROVIDER_API_BASE,
@@ -51,7 +52,7 @@ function createProviderConfig(
     name: "Command Code",
     baseUrl: apiBase,
     apiKey: getConfiguredApiKey() ?? "$COMMANDCODE_API_KEY",
-    api: "openai-completions",
+    api: "commandcode-custom",
     streamSimple: streamCommandCode,
     headers,
     oauth: {
@@ -63,7 +64,7 @@ function createProviderConfig(
     models: models.map((model) => ({
       id: model.id,
       name: model.name,
-      api: model.api,
+      api: "commandcode-custom",
       baseUrl: baseUrlForModel(apiBase, model.api),
       reasoning: model.reasoning,
       ...(thinkingMetadataForModel(model.id) ?? {}),
@@ -108,7 +109,12 @@ export default async function (pi: ExtensionAPI) {
   })
   const transport = createCommandCodeTransportRouter({
     createStream: () => new AssistantMessageEventStream(),
-    streamProvider: streamNativeProvider,
+    streamProvider: (model, context, options) =>
+      streamNativeProvider(
+        { ...model, api: apiForModelId(model.id), compat: model.compatConfig ?? model.compat },
+        context,
+        options,
+      ),
     streamGenerate,
   })
 


### PR DESCRIPTION
## Problem

Loading the extension in `omp` 17.4.0 crashes with:

```
Cannot register custom API "openai-completions": built-in API names are reserved
```

`index.ts` registers the provider and every model under `api: "openai-completions"`. Newer pi hosts (omp 17.4.0's bundled `@oh-my-pi/pi-coding-agent`) reject `registerCustomApi` calls under any built-in API name, so the extension fails to load and `omp models` / any Command Code request errors out before it starts.

## Fix

- Register the provider and its models under `"commandcode-custom"` instead (the same non-reserved name the published `0.5.1` npm build already uses — the local checkout had drifted from it).
- The transport router now needs to recover the *real* wire API before handing the model to the native compat stream, since the model's `api` field is now the custom name. `streamProvider` restores it via `apiForModelId(model.id)`.
- Restoring only `api` was not enough: the host's model registry stores provider-supplied `compat` internally as `model.compatConfig`, and only copies it back onto `model.compat` inside the host's own dispatch-time patches. Since the router calls the native compat `streamSimple` directly, it must read `model.compatConfig ?? model.compat` itself, or the request throws `TypeError: undefined is not an object (evaluating 'baseCompat.disableReasoningOnForcedToolChoice')` before any network call is made.

## Verification

- `npm run typecheck` — clean.
- `npm run format:check` — clean.
- `npx tsx tests/test-runtime.ts` — passing.
- Linked the extension into a local omp 17.4.0 install (`omp plugin link`) and confirmed `omp models` no longer crashes and lists all 57 Command Code models.
- End-to-end against a local mock Provider API server (mock `/provider/v1/models` + `/provider/v1/chat/completions`): `omp -p "hi" --model commandcode/deepseek/deepseek-v4-flash` with `COMMANDCODE_ZDR=1` completed successfully, and the mock server observed the resolved `Authorization: Bearer <key>` header and the `x-cmd-zdr: 1` header on the real request — confirming registration, transport routing, native compat dispatch, and ZDR headers all work together.

Did not run the full `npm test` suite's `tests/test-omp-compat.mjs` / `test-pi-*.mjs` scripts — they invoke omp with `--list-models`/`-e`, flags that no longer exist on the installed omp 17.4.0 CLI (a separate, pre-existing incompatibility unrelated to this fix).