### PR TITLE
feat(models): add GLM-5.3 pricing and reasoning levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `zai-org/GLM-5.3` with its verified reasoning efforts and display pricing.
 - Prefer Command Code's Provider API (`/provider/v1/chat/completions` and `/provider/v1/messages`) and automatically fall back to the existing `/alpha/generate` transport only when the Provider API returns `403 upgrade_required` for a Go-plan account.
 - Remember the detected transport for the running process, re-detect it when credentials change, prevent stale in-flight requests from overwriting the new credential's transport, and never fall back for unrelated authentication, permission, rate-limit, network, or server failures.
 - Use Pi's native OpenAI- and Anthropic-compatible providers for Provider API streaming, including adaptive thinking for current reasoning-capable Claude models, while preserving the existing hardened generate transport, dynamic model discovery, offline cache, refresh/status commands, pricing, and OAuth credentials.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The following environment variables are intended for tests, local mocks, and com
 
 ## Image input
 
-The provider advertises image input only for models marked with the `image` input modality in the official Command Code CLI model catalog. The capability snapshot currently follows `command-code@1.15.1`; unknown models default to text-only until their upstream metadata is reviewed.
+The provider advertises image input only for models marked with the `image` input modality in the official Command Code CLI model catalog. The capability snapshot currently follows `command-code@1.32.1`; unknown models default to text-only until their upstream metadata is reviewed.
 
 For vision-capable models, Pi's native provider adapters forward image blocks from user messages and tool results using the documented OpenAI or Anthropic message schema. Unknown and text-only models remain marked text-only in Pi.
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -43,7 +43,7 @@ export * from "./overflow.ts"
 export * from "./types.ts"
 
 export const DEFAULT_API_BASE = "https://api.commandcode.ai"
-export const COMMAND_CODE_CLI_VERSION = "1.15.1"
+export const COMMAND_CODE_CLI_VERSION = "1.32.1"
 
 const DEFAULT_GENERATE_MAX_TOKENS = 64_000
 const DEFAULT_MAX_RETRIES = 0

--- a/src/models.ts
+++ b/src/models.ts
@@ -12,7 +12,7 @@ export type CommandCodeApi = "openai-completions" | "anthropic-messages"
 export type CommandCodeInputType = "text" | "image"
 
 /**
- * Model input modalities from the command-code@1.15.1 bundled catalog.
+ * Model input modalities from the command-code@1.32.1 bundled catalog.
  * Models omitted here remain text-only so newly discovered IDs never claim
  * image support without upstream evidence.
  */
@@ -74,7 +74,7 @@ type CommandCodeReasoningEffort = Exclude<PiThinkingLevel, "off">
  * Per-model reasoning efforts supported by Command Code's generate endpoint.
  *
  * The Provider API does not expose reasoning metadata. This is an exact
- * snapshot of `reasoningEfforts` from the command-code@1.15.1 model catalog
+ * snapshot of `reasoningEfforts` from the command-code@1.32.1 model catalog
  * (`packages/shared/src/model-catalog.ts`, also published in the generated
  * `dist/bundled/command-code-knowledge/reference/models.md`). Models omitted
  * here let Command Code choose their reasoning depth, matching the CLI.
@@ -103,6 +103,7 @@ export const MODEL_EFFORTS: Readonly<Record<string, readonly CommandCodeReasonin
   "sakana/fugu-ultra": ["high", "xhigh"],
   "xai/grok-4.5": ["low", "medium", "high"],
   "zai-org/GLM-5.2": ["high", "max"],
+  "zai-org/GLM-5.3": ["low", "high", "max"],
 }
 
 const PI_THINKING_LEVELS: readonly PiThinkingLevel[] = [

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -20,7 +20,7 @@ export interface TemporaryPricing {
 }
 
 export const PRICING_SOURCE_URL = "https://commandcode.ai/docs/resources/pricing-limits"
-export const PRICING_LAST_VERIFIED = "2026-08-20"
+export const PRICING_LAST_VERIFIED = "2026-08-22"
 
 export const ZERO_MODEL_COST: CommandCodeModelCost = {
   input: 0,
@@ -54,6 +54,7 @@ export const MODEL_COSTS: Readonly<Record<string, CommandCodeModelCost>> = {
   },
   "moonshotai/Kimi-K2.6": { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 },
   "moonshotai/Kimi-K2.5": { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0 },
+  "zai-org/GLM-5.3": { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
   "zai-org/GLM-5.2": { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
   "zai-org/GLM-5.2-Fast": { input: 3, output: 10.25, cacheRead: 0.5, cacheWrite: 0 },
   "zai-org/GLM-5.1": { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },

--- a/tests/fixtures/commandcode-model-ids.json
+++ b/tests/fixtures/commandcode-model-ids.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-08-04T10:12:57.953Z",
+  "fetchedAt": "2026-08-22T21:19:37.782Z",
   "source": "https://api.commandcode.ai/provider/v1/models",
   "modelIds": [
     "claude-sonnet-5",
@@ -23,6 +23,7 @@
     "moonshotai/Kimi-K2.7-Code-Highspeed",
     "moonshotai/Kimi-K2.6",
     "moonshotai/Kimi-K2.5",
+    "zai-org/GLM-5.3",
     "zai-org/GLM-5.2",
     "zai-org/GLM-5.2-Fast",
     "zai-org/GLM-5.1",

--- a/tests/fixtures/commandcode-pricing.json
+++ b/tests/fixtures/commandcode-pricing.json
@@ -1,5 +1,5 @@
 {
-  "verifiedAt": "2026-08-20",
+  "verifiedAt": "2026-08-22",
   "source": "https://commandcode.ai/docs/resources/pricing-limits",
   "tierPolicy": "Use request-wide input tiers; the highest threshold exceeded by input plus cache tokens applies to the full request.",
   "tiers": {
@@ -18,6 +18,7 @@
     "moonshotai/Kimi-K2.7-Code-Highspeed": [1.9, 8, 0.38, 0],
     "moonshotai/Kimi-K2.6": [0.95, 4, 0.16, 0],
     "moonshotai/Kimi-K2.5": [0.6, 3, 0.1, 0],
+    "zai-org/GLM-5.3": [1.4, 4.4, 0.26, 0],
     "zai-org/GLM-5.2": [1.4, 4.4, 0.26, 0],
     "zai-org/GLM-5.2-Fast": [3, 10.25, 0.5, 0],
     "zai-org/GLM-5.1": [1.4, 4.4, 0.26, 0],

--- a/tests/test-models.ts
+++ b/tests/test-models.ts
@@ -100,7 +100,7 @@ describe("commandCodeModelsFromApiResponse()", () => {
     )
   })
 
-  it("matches command-code@1.15.1 image input capabilities", () => {
+  it("matches command-code@1.32.1 image input capabilities", () => {
     assert.deepEqual(inputModalitiesForModel("gpt-5.6-luna"), ["text", "image"])
     assert.deepEqual(inputModalitiesForModel("meta/muse-spark-1.2"), ["text", "image"])
     assert.deepEqual(inputModalitiesForModel("deepseek/deepseek-v4-pro"), ["text"])
@@ -123,7 +123,7 @@ describe("commandCodeModelsFromApiResponse()", () => {
     assert.equal(models[1]?.reasoning, false)
   })
 
-  it("matches the exact command-code@1.15.1 reasoning effort catalog", () => {
+  it("matches the exact command-code@1.32.1 reasoning effort catalog", () => {
     assert.deepEqual(MODEL_EFFORTS, {
       "Qwen/Qwen3.8-Max": ["low", "medium", "xhigh"],
       "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
@@ -147,6 +147,7 @@ describe("commandCodeModelsFromApiResponse()", () => {
       "google/gemini-3.6-flash": ["low", "medium", "high"],
       "sakana/fugu-ultra": ["high", "xhigh"],
       "xai/grok-4.5": ["low", "medium", "high"],
+      "zai-org/GLM-5.3": ["low", "high", "max"],
       "zai-org/GLM-5.2": ["high", "max"],
     })
   })

--- a/tests/test-pricing.ts
+++ b/tests/test-pricing.ts
@@ -50,7 +50,7 @@ function assertCost(
 describe("MODEL_COSTS pricing overlay", () => {
   it("covers the current Command Code model catalog snapshot", () => {
     assert.equal(fixture.source, "https://api.commandcode.ai/provider/v1/models")
-    assert.match(fixture.fetchedAt, /^2026-08-04T/)
+    assert.match(fixture.fetchedAt, /^2026-08-22T/)
 
     const catalogIds = [...fixture.modelIds].sort()
     const pricedIds = Object.keys(MODEL_COSTS).sort()
@@ -169,7 +169,7 @@ describe("MODEL_COSTS pricing overlay", () => {
 
   it("tracks pricing provenance", () => {
     assert.equal(PRICING_SOURCE_URL, "https://commandcode.ai/docs/resources/pricing-limits")
-    assert.equal(PRICING_LAST_VERIFIED, "2026-08-20")
+    assert.equal(PRICING_LAST_VERIFIED, "2026-08-22")
   })
 
   it("fails once temporary pricing needs review", () => {

--- a/tests/test-stream.ts
+++ b/tests/test-stream.ts
@@ -488,7 +488,7 @@ describe("streamCommandCode — request serialization", () => {
 
     const headers = server.lastRequestHeaders()
     assert.equal(headers.authorization, "Bearer mock-key")
-    assert.equal(headers["x-command-code-version"], "1.15.1")
+    assert.equal(headers["x-command-code-version"], "1.32.1")
     assert.equal(headers["x-project-slug"], "repo")
     assert.equal(headers["x-taste-learning"], "true")
     assert.equal(headers["x-co-flag"], "false")


### PR DESCRIPTION
Why:
Allows the GLM-5.3 model from Z.ai to have reasoning levels.

Reasoning levels from command-code@1.32.1 and seen here:

<img width="461" height="128" alt="GLM-5 3-reasoning-efforts" src="https://github.com/user-attachments/assets/26870b14-1123-458a-a972-beb53506f6c0" />

Pricing taken from the official command-code docs - they are the same as GLM-5.2 (GLM-5.3 has a lower allowance that 5.2 however).

Ran tests, however I do not own a command-code subscription to *actually* run GLM-5.3 on command-code with pi.dev.
Feel free to modify or remove this PR at your convenience.