### PR TITLE
fix(models): add image support for deepseek/deepseek-v4-flash-vision-exp

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -43,6 +43,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "meta/muse-spark-1.1": ["text", "image"],
   "meta/muse-spark-1.2": ["text", "image"],
   "meta/muse-spark-1.2-contributor": ["text", "image"],
+  "deepseek/deepseek-v4-flash-vision-exp": ["text", "image"],
   "moonshotai/Kimi-K2.5": ["text", "image"],
   "moonshotai/Kimi-K2.6": ["text", "image"],
   "moonshotai/Kimi-K2.7-Code": ["text", "image"],

--- a/tests/test-models.ts
+++ b/tests/test-models.ts
@@ -103,11 +103,13 @@ describe("commandCodeModelsFromApiResponse()", () => {
   it("matches command-code@1.32.1 image input capabilities", () => {
     assert.deepEqual(inputModalitiesForModel("gpt-5.6-luna"), ["text", "image"])
     assert.deepEqual(inputModalitiesForModel("meta/muse-spark-1.2"), ["text", "image"])
+    assert.deepEqual(inputModalitiesForModel("deepseek/deepseek-v4-flash-vision-exp"), ["text", "image"])
     assert.deepEqual(inputModalitiesForModel("deepseek/deepseek-v4-pro"), ["text"])
     assert.deepEqual(inputModalitiesForModel("unknown-new-model"), ["text"])
     assert.equal(modelSupportsImageInput("gpt-5.6-luna"), true)
+    assert.equal(modelSupportsImageInput("deepseek/deepseek-v4-flash-vision-exp"), true)
     assert.equal(modelSupportsImageInput("deepseek/deepseek-v4-pro"), false)
-    assert.equal(Object.keys(MODEL_INPUT_MODALITIES).length, 37)
+    assert.equal(Object.keys(MODEL_INPUT_MODALITIES).length, 38)
   })
 
   it("marks only known reasoning models as reasoning-capable", () => {

--- a/tests/test-models.ts
+++ b/tests/test-models.ts
@@ -103,7 +103,10 @@ describe("commandCodeModelsFromApiResponse()", () => {
   it("matches command-code@1.32.1 image input capabilities", () => {
     assert.deepEqual(inputModalitiesForModel("gpt-5.6-luna"), ["text", "image"])
     assert.deepEqual(inputModalitiesForModel("meta/muse-spark-1.2"), ["text", "image"])
-    assert.deepEqual(inputModalitiesForModel("deepseek/deepseek-v4-flash-vision-exp"), ["text", "image"])
+    assert.deepEqual(inputModalitiesForModel("deepseek/deepseek-v4-flash-vision-exp"), [
+      "text",
+      "image",
+    ])
     assert.deepEqual(inputModalitiesForModel("deepseek/deepseek-v4-pro"), ["text"])
     assert.deepEqual(inputModalitiesForModel("unknown-new-model"), ["text"])
     assert.equal(modelSupportsImageInput("gpt-5.6-luna"), true)

--- a/tests/test-stream.ts
+++ b/tests/test-stream.ts
@@ -173,6 +173,85 @@ describe("streamCommandCode — successful streams", () => {
     )
   })
 
+  it("forwards a tool-result image as a following user image for vision-capable models", async () => {
+    server.mockResponse({
+      type: "success",
+      events: [JSON.stringify({ type: "finish", finishReason: "stop" })],
+    })
+    const { streamCommandCode } = createTestDeps({ apiBase: server.baseUrl() })
+
+    const events = await collectEvents(
+      streamCommandCode(
+        makeModel({ id: "deepseek/deepseek-v4-flash-vision-exp" }),
+        makeContext({
+          messages: [
+            { role: "user", content: "read the image" },
+            {
+              role: "assistant",
+              content: [{ type: "toolCall", id: "c1", name: "read", arguments: {} }],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "c1",
+              toolName: "read",
+              content: [
+                { type: "text", text: "image attached" },
+                { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+              ],
+            },
+          ],
+        }),
+        { apiKey: "mock-key" },
+      ),
+    )
+
+    // No error: the tool-result image must not be rejected for this model.
+    assert.equal(events.at(-1)?.type, "done")
+
+    const body = server.lastRequestBody()
+    // The tool-result text is forwarded on the tool message at index 2.
+    assert.equal(
+      objectAt(body, ["params", "messages", "2", "content", "0", "output", "value"]),
+      "image attached",
+    )
+    // The tool-result image is forwarded as a following user image message at index 3.
+    assert.equal(objectAt(body, ["params", "messages", "3", "role"]), "user")
+    assert.equal(
+      objectAt(body, ["params", "messages", "3", "content", "0", "image"]),
+      "data:image/png;base64,aGVsbG8=",
+    )
+  })
+
+  it("rejects a tool-result image before network access for text-only models", async () => {
+    const { streamCommandCode } = createTestDeps({ apiBase: server.baseUrl() })
+
+    const events = await collectEvents(
+      streamCommandCode(
+        makeModel({ id: "deepseek/deepseek-v4-pro" }),
+        makeContext({
+          messages: [
+            { role: "user", content: "read the image" },
+            {
+              role: "assistant",
+              content: [{ type: "toolCall", id: "c1", name: "read", arguments: {} }],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "c1",
+              toolName: "read",
+              content: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }],
+            },
+          ],
+        }),
+        { apiKey: "mock-key" },
+      ),
+    )
+
+    assert.equal(events.at(-1)?.type, "error")
+    assert.match(events.at(-1)?.error.errorMessage ?? "", /does not support image content/i)
+    assert.equal(server.requestCount(), 0)
+  })
+
   it("rejects images before network access for text-only models", async () => {
     const { streamCommandCode } = createTestDeps({ apiBase: server.baseUrl() })
 

--- a/tests/test-stream.ts
+++ b/tests/test-stream.ts
@@ -247,8 +247,10 @@ describe("streamCommandCode — successful streams", () => {
       ),
     )
 
-    assert.equal(events.at(-1)?.type, "error")
-    assert.match(events.at(-1)?.error.errorMessage ?? "", /does not support image content/i)
+    const lastEvent = events.at(-1)
+    assert.equal(lastEvent?.type, "error")
+    if (lastEvent?.type !== "error") throw new Error("expected error event")
+    assert.match(lastEvent.error.errorMessage ?? "", /does not support image content/i)
     assert.equal(server.requestCount(), 0)
   })
 


### PR DESCRIPTION
## Problem

`deepseek/deepseek-v4-flash-vision-exp` is served by the Provider API but is missing from the hardcoded `MODEL_INPUT_MODALITIES` allowlist in `src/models.ts`. Because unknown model IDs default to text-only, pi rejects any conversation containing an image block — including images returned by the `read` tool via `toolResult`:

```
Selected Command Code model does not support image content in tool results
```

This is the exact reproduction:

```
read ~/cps_test/SACPS_checkbox_style_preview.png

Error: Selected Command Code model does not support image content in tool results
```

### Root cause

`inputModalitiesForModel(id)` returns `MODEL_INPUT_MODALITIES[id] ?? ["text"]`. The vision-exp entry was absent, so `modelSupportsImageInput("deepseek/deepseek-v4-flash-vision-exp")` returned `false`. `src/core.ts` then calls `assertTextOnlyMessages(context.messages)` (via `allowImages=false`), which throws `imageContentError` for any image block — for both `user` pastes and `toolResult` images (`src/converters.ts`).

## Fix

One allowlist entry:

```diff
  "meta/muse-spark-1.2-contributor": ["text", "image"],
+ "deepseek/deepseek-v4-flash-vision-exp": ["text", "image"],
  "moonshotai/Kimi-K2.5": ["text", "image"],
```

After this, `modelSupportsImageInput("deepseek/deepseek-v4-flash-vision-exp") === true` and `messagesToCC` forwards images via the current Command Code wire format.

## Coverage

Rebased on current `main` (`command-code@1.32.1`) and addresses the review findings:

1. **Regression test** for `modelSupportsImageInput("deepseek/deepseek-v4-flash-vision-exp")` (+ `inputModalitiesForModel`) in `tests/test-models.ts`. The allowlist count assertion moves `37 -> 38`.
2. **End-to-end stream test** (in `tests/test-stream.ts`) covering a tool-result image forwarded as a following `user` image — the concrete `read` reproduction, not only a user-attached image. A second stream test asserts a text-only model (`deepseek/deepseek-v4-pro`) still rejects a tool-result image *before any network access*.
3. **Version reference** now points at the current `command-code@1.32.1` catalog snapshot (kept consistent with `main`).

All tests pass:

```
tests/test-models.ts - 20 pass, 0 fail
tests/test-stream.ts - 29 pass, 0 fail
```

## Related

Same root cause as #54 (deepseek-v4-flash-vision-exp missing vision capability). This PR can close #54 as a duplicate once merged.

## Risk

Low. One allowlist entry matching the Provider API catalog. No new API surface or behavioral change for already-allowlisted models.
