### PR TITLE
Display monthly quota renewal date

### DIFF
--- a/src/quota-format.ts
+++ b/src/quota-format.ts
@@ -49,10 +49,42 @@ function creditsDetail(credits: CommandCodeCredits | null): string | undefined {
   return `Sources: ${parts.join(" / ")}`
 }
 
-function subscriptionLine(subscription: CommandCodeSubscription): string {
+function parsePeriodEnd(value: string): Date | null {
+  const trimmed = value.trim()
+  const timestamp = /^\d+$/.test(trimmed) ? Number(trimmed) : Date.parse(trimmed)
+  if (!Number.isFinite(timestamp) || timestamp < 0) return null
+  const milliseconds = timestamp >= 1e12 ? timestamp : timestamp * 1000
+  const date = new Date(milliseconds)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function subscriptionLine(
+  subscription: CommandCodeSubscription,
+  now: () => number = Date.now,
+): string {
   const plan = (subscription.planId ?? "Unknown").replace(/[_-]+/g, " ").trim()
   const status = subscription.status ? ` (${subscription.status})` : ""
-  return `Plan: ${plan}${status}`
+  let renewal = ""
+  if (subscription.currentPeriodEnd) {
+    const end = parsePeriodEnd(subscription.currentPeriodEnd)
+    if (end) {
+      const diffMs = end.getTime() - now()
+      const days = Math.ceil(diffMs / 86_400_000)
+      const dateStr = end.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      })
+      if (days > 0) {
+        renewal = ` · renews ${dateStr} (${days}d)`
+      } else if (days === 0) {
+        renewal = ` · renews ${dateStr} (today)`
+      } else {
+        renewal = ` · renewed ${dateStr}`
+      }
+    }
+  }
+  return `Plan: ${plan}${status}${renewal}`
 }
 
 function formatTokens(tokens: number): string {
@@ -77,7 +109,7 @@ export function formatQuota(quota: CommandCodeQuota, now: () => number = Date.no
 
   const detail = creditsDetail(quota.credits)
   if (detail) lines.push(detail)
-  if (quota.subscription) lines.push(subscriptionLine(quota.subscription))
+  if (quota.subscription) lines.push(subscriptionLine(quota.subscription, now))
 
   if (quota.summary) {
     lines.push("")

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -43,6 +43,13 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined
 }
 
+function timestampValue(value: unknown): string | undefined {
+  const text = stringValue(value)
+  if (text) return text
+  const number = numberValue(value)
+  return number === undefined ? undefined : String(number)
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
@@ -100,8 +107,8 @@ function parseSubscription(value: unknown): CommandCodeSubscription | null {
   const data = value.data
   const planId = stringValue(data.planId)
   const status = stringValue(data.status)
-  const currentPeriodStart = stringValue(data.currentPeriodStart)
-  const currentPeriodEnd = stringValue(data.currentPeriodEnd)
+  const currentPeriodStart = timestampValue(data.currentPeriodStart)
+  const currentPeriodEnd = timestampValue(data.currentPeriodEnd)
   if (!planId && !status && !currentPeriodStart && !currentPeriodEnd) return null
   return {
     planId: planId ?? null,

--- a/tests/test-quota.ts
+++ b/tests/test-quota.ts
@@ -276,7 +276,13 @@ describe("Command Code quota", () => {
     const { fetchImpl } = okFetch({
       whoami: { user: { userName: "alice", keyName: "Pi Agent" }, org: null },
       credits: { credits: { monthlyCredits: 5, purchasedCredits: 0, freeCredits: 0 } },
-      subscriptions: { data: { planId: "pro", status: "active" } },
+      subscriptions: {
+        data: {
+          planId: "pro",
+          status: "active",
+          currentPeriodEnd: Date.parse("2026-02-01T00:00:00Z"),
+        },
+      },
       summary: { totalCost: 1.06, totalCount: 654, totalTokens: 74_200_000 },
     })
     const result = await fetchCommandCodeQuota({ apiKey: "cc_test_key", fetchImpl })
@@ -284,6 +290,7 @@ describe("Command Code quota", () => {
     if (!result.ok) return
     assert.equal(result.quota.summary?.totalTokens, 74_200_000)
     assert.equal(result.quota.account.keyName, "Pi Agent")
+    assert.equal(result.quota.subscription?.currentPeriodEnd, "1769904000000")
   })
 
   it("rejects missing API keys as a config error", async () => {
@@ -327,13 +334,13 @@ describe("Command Code quota", () => {
       summary: { totalCost: 12.34, totalCount: 1500 },
     }
 
-    const output = formatQuota(quota, () => 1_700_000_000_000)
+    const output = formatQuota(quota, () => Date.parse("2026-01-15T00:00:00Z"))
     assert.doesNotMatch(output, /Command Code quota —/)
     assert.match(output, /Credits/)
     assert.match(output, /Remaining: \$55\.00 of \$67\.34/)
     assert.match(output, /Used: \$12\.34/)
     assert.match(output, /Sources: monthly \$40\.00 \/ purchased \$10\.00 \/ free \$5\.00/)
-    assert.match(output, /Plan: pro \(active\)/)
+    assert.match(output, /Plan: pro \(active\) · renews Feb 1 \(17d\)/)
     assert.match(output, /Usage \(billing period\)/)
     assert.match(output, /Cost: \$12\.34/)
     assert.match(output, /Requests: 1,500/)
@@ -342,6 +349,48 @@ describe("Command Code quota", () => {
     assert.match(output, /5-hour: 8\.00 \/ 16\.00 credits/)
     assert.match(output, /Weekly: 20\.00 \/ 40\.00 credits/)
     assert.match(output, /https:\/\/commandcode\.ai\/usage/)
+  })
+
+  it("formats renewal dates in UTC and handles renewal edge cases", () => {
+    const baseQuota: CommandCodeQuota = {
+      account: { login: "alice", orgId: null },
+      credits: null,
+      subscription: null,
+      summary: null,
+    }
+    const formatRenewal = (currentPeriodEnd: string | null, now: string) =>
+      formatQuota(
+        {
+          ...baseQuota,
+          subscription: {
+            planId: "pro",
+            status: "active",
+            currentPeriodStart: null,
+            currentPeriodEnd,
+          },
+        },
+        () => Date.parse(now),
+      )
+
+    const beforeReset = formatRenewal("2026-02-01T00:00:00Z", "2026-01-31T12:00:00Z")
+    assert.match(beforeReset, /Plan: pro \(active\) · renews Feb 1 \(1d\)/)
+
+    const numericTimestamp = formatRenewal(
+      String(Date.parse("2026-02-01T00:00:00Z")),
+      "2026-01-31T12:00:00Z",
+    )
+    assert.match(numericTimestamp, /Plan: pro \(active\) · renews Feb 1 \(1d\)/)
+
+    const today = formatRenewal("2026-01-31T12:00:00Z", "2026-01-31T12:00:00Z")
+    assert.match(today, /Plan: pro \(active\) · renews Jan 31 \(today\)/)
+
+    const expired = formatRenewal("2026-01-30T00:00:00Z", "2026-01-31T12:00:00Z")
+    assert.match(expired, /Plan: pro \(active\) · renewed Jan 30/)
+
+    for (const currentPeriodEnd of [null, "not-a-date"]) {
+      const output = formatRenewal(currentPeriodEnd, "2026-01-31T12:00:00Z")
+      assert.doesNotMatch(output, /renews|renewed/)
+    }
   })
 
   it("redacts token-like values from error messages", () => {


### PR DESCRIPTION
# Display monthly renewal date in `commandcode-quota`

## Summary

`/commandcode-quota` already fetched `currentPeriodEnd` from Command Code's subscription endpoint, but the formatter did not display it. I apologize, I forgot to test that.

This change adds the renewal date and remaining-day countdown to the plan line.

Example:

```text
Plan: pro (active) · renews Sep 5 (12d)
```

Renewal dates are rendered in UTC to match the API timestamp. Numeric epoch values, ISO timestamps, invalid dates, and missing dates are handled explicitly. The countdown uses `formatQuota`'s injectable clock for deterministic tests.

## Validation

Automated:

- `npm run typecheck`
- `npm run test:unit`
- `npm run test:quota`
- Prettier check on changed files
- `git diff --check`

Manual:

- OMP integration and `/commandcode-quota` were hand-tested by me.

Known test-environment issue:

- The full `npm test` suite reaches the existing OMP compatibility test but fails because it observes 4 model-list requests where the test expects 1. This is unrelated to the quota changes.

## Scope

- `src/quota-format.ts`: render and normalize subscription renewal dates.
- `tests/test-quota.ts`: cover UTC rendering, exact countdowns, numeric timestamps, today/expired dates, and invalid or missing values.
