### PR TITLE
fix: add muse-spark thinking levels and fix reasoning fallback

### DIFF
--- a/src/commandcode-catalog.ts
+++ b/src/commandcode-catalog.ts
@@ -103,6 +103,10 @@ export const MODEL_REASONING: Readonly<Record<string, true>> = {
 }
 
 export const MODEL_EFFORTS: Readonly<Record<string, readonly CommandCodeReasoningEffort[]>> = {
+  "meta/muse-spark-1.1": ["minimal", "low", "medium", "high", "xhigh"],
+  "meta/muse-spark-1.2": ["minimal", "low", "medium", "high", "xhigh"],
+  "meta/muse-spark-1.2-contributor": ["minimal", "low", "medium", "high", "xhigh"],
+  "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-7": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-8": ["low", "medium", "high", "xhigh", "max"],

--- a/src/models.ts
+++ b/src/models.ts
@@ -77,7 +77,7 @@ export function thinkingMetadataForModel(modelId: string): ThinkingMetadata | un
     }
   }
   if (!isReasoningModel(modelId)) return undefined
-  return { thinkingLevelMap: thinkingLevelMapForEfforts([]) }
+  return undefined
 }
 
 function isReasoningModel(modelId: string): boolean {


### PR DESCRIPTION
### 修复

commandcode/meta/muse-spark-1.2-contributor 及 1.1/1.2 切 COT 等级无效，切 :high 仍为 off。

#### 根因
- src/commandcode-catalog.ts MODEL_EFFORTS 漏了三条 muse-spark，仅 MODEL_REASONING 为 true
- src/models.ts:80 fallback thinkingLevelMapForEfforts([]) -> 全 null -> pi 0.84.4 getSupportedThinkingLevels=[off]，clamp(:high)->off，supportsReasoningEffort=false 也不发 reasoningEffort
- 本地验证：models.json 用 modelOverrides 覆盖已可 :high/:xhigh 生效（max:null 保留，夹到 xhigh 符合 openrouter 预期）

#### 改动
- commandcode-catalog.ts: 补 MODEL_EFFORTS[meta/muse-spark-1.1/1.2/1.2-contributor]=[minimal,low,medium,high,xhigh] 对齐 openrouter 定义
- models.ts: 无显式 efforts 的推理模型返回 undefined 而非全 null map，让 pi 走默认 off..high，顺带修 Kimi-K3/MiniMax 等同病

#### 验证
- 本机 models.json 覆盖 + /reload 后 /model 档位为 minimal/low/medium/high/xhigh
- prettier --write 已跑过

Fixes COT level clamp for commandcode/meta/muse-spark-1.2-contributor