### PR TITLE
docs(readme): fold the extension compat note into Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ omp plugin install pi-commandcode-provider
 
 Restart OMP or run `/reload`, then use `/login` and select **Use a subscription** followed by **Command Code**.
 
-## Other extensions
-
-Command Code models are registered under the custom `commandcode-custom` API. The provider also registers that API in the `@earendil-works/pi-ai/compat` registry, so sibling extensions that stream through `streamSimple` from that entrypoint with the active session model (background agents, memory workers, and similar) reach the same Command Code transport instead of failing with `No API provider registered for api: commandcode-custom`. When such a call passes no API key, the provider uses the configured Command Code credentials.
-
 ## Authentication
 
 ### Login dialog
@@ -85,6 +81,8 @@ Supported examples:
 ## Usage
 
 Open `/model` and select one of the models provided by Command Code. Model availability changes over time and is refreshed from the Provider API when the extension loads.
+
+Other extensions that stream with the active Command Code model, such as background agents or memory workers, use the same connection and the same credentials as the chat, so their requests count against your Command Code usage.
 
 ### Reasoning support
 


### PR DESCRIPTION
Removes the "Other extensions" section added with #68 and keeps the user-relevant part as one sentence under **Usage**: sibling extensions that stream with the active Command Code model share the connection and credentials, so their requests count against Command Code usage. The registry mechanics remain documented in `index.ts` and the changelog.