### PR TITLE
ci: run Bun 1.4.0 in the memory benchmark and omp jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.4.0
       - run: npm ci
       - name: Install Oh My Pi
         run: |

--- a/.github/workflows/memory-benchmark.yml
+++ b/.github/workflows/memory-benchmark.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       contents: read
     env:
-      PI_VERSION: 0.82.1
-      BUN_VERSION: 1.3.11
-      NODE_VERSION: 22.19.0
+      PI_VERSION: 0.84.4
+      BUN_VERSION: 1.4.0
+      NODE_VERSION: 22.23.2
       MEMORY_BENCHMARK_RUNS: 6
       MEMORY_BENCHMARK_WARMUP_MS: 2500
       MEMORY_BENCHMARK_SAMPLES: 12


### PR DESCRIPTION
Bumps the memory benchmark runtime pins to current stable releases and aligns the omp job:

| | before | after |
|---|---|---|
| Bun (memory benchmark) | 1.3.11 | **1.4.0** |
| Bun (Oh My Pi compatibility) | `latest` | **1.4.0** |
| Node (memory benchmark) | 22.19.0 | 22.23.2 |
| pi host (memory benchmark) | 0.82.1 | 0.84.4 |

The omp job is a required check, so a fixed Bun release keeps it reproducible; Oh My Pi 18.1.2 requires Bun ≥ 1.3.14.