### PR TITLE
fix(converters): batch consecutive tool results before emitting images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Batch consecutive tool-result images after all tool results on the generate transport, preventing interleaved user messages from breaking multi-tool turns with "Tool result is missing".
+
 ## 0.6.4 - 2026-09-03
 
 - Refresh the generated Command Code capability catalog from `command-code@1.40.1` to `command-code@1.44.0`, adding current image-input, reasoning, effort, and output-limit metadata for newly published models.

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -245,7 +245,9 @@ export function messagesToCC(
   const out: unknown[] = []
   const { callIds, resultIds } = toolCallState(messages)
 
-  for (const message of messages ?? []) {
+  const rawMessages = messages ?? []
+  for (let i = 0; i < rawMessages.length; i++) {
+    const message = rawMessages[i]
     if (message.role === "user" || message.role === "developer") {
       // Hosts such as OMP steer the agent by injecting developer-role messages
       // (advisor notes, reminders, nudges) mid-conversation. /alpha/generate
@@ -288,30 +290,42 @@ export function messagesToCC(
       if (parts.length > 0) out.push({ role: "assistant", content: parts })
       if (missingResults.length > 0) out.push({ role: "tool", content: missingResults })
     } else if (message.role === "toolResult") {
-      if (!message.toolCallId || !callIds.has(message.toolCallId)) continue
-      const images = imageParts(message.content)
-      const text = textContent(message)
-      const outputText =
-        text ||
-        (images.length > 0 && !allowImages ? "[Image omitted: model does not support images]" : "")
-      out.push({
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: message.toolCallId,
-            toolName: message.toolName,
-            output: message.isError
-              ? { type: "error-text", value: outputText }
-              : { type: "text", value: outputText },
-          },
-        ],
-      })
+      const pendingImages: Record<string, string>[] = []
+      let j = i
+      for (; j < rawMessages.length && rawMessages[j].role === "toolResult"; j++) {
+        const toolMsg = rawMessages[j]
+        if (!toolMsg.toolCallId || !callIds.has(toolMsg.toolCallId)) continue
+        const images = imageParts(toolMsg.content)
+        const text = textContent(toolMsg)
+        const outputText =
+          text ||
+          (images.length > 0 && !allowImages
+            ? "[Image omitted: model does not support images]"
+            : "")
+        out.push({
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: toolMsg.toolCallId,
+              toolName: toolMsg.toolName,
+              output: toolMsg.isError
+                ? { type: "error-text", value: outputText }
+                : { type: "text", value: outputText },
+            },
+          ],
+        })
 
-      if (images.length > 0 && allowImages) {
+        if (images.length > 0 && allowImages) {
+          pendingImages.push(...images.map(imageToCommandCode))
+        }
+      }
+      i = j - 1
+
+      if (pendingImages.length > 0) {
         out.push({
           role: "user",
-          content: images.map(imageToCommandCode),
+          content: pendingImages,
         })
       }
     }

--- a/tests/test-pure-functions.ts
+++ b/tests/test-pure-functions.ts
@@ -712,6 +712,60 @@ describe("messagesToCC()", () => {
     })
   })
 
+  it("batches consecutive tool-result images after all tool results instead of interleaving user messages", () => {
+    const result = messagesToCC(
+      [
+        { role: "user", content: "read two images" },
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "c1", name: "read", arguments: { path: "a.png" } },
+            { type: "toolCall", id: "c2", name: "read", arguments: { path: "b.png" } },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "c1",
+          toolName: "read",
+          content: [
+            { type: "text", text: "image a" },
+            { type: "image", data: "YWFh", mimeType: "image/png" },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "c2",
+          toolName: "read",
+          content: [
+            { type: "text", text: "image b" },
+            { type: "image", data: "YmJi", mimeType: "image/png" },
+          ],
+        },
+      ],
+      { allowImages: true },
+    )
+
+    assert.equal(objectAt(result, ["2", "role"]), "tool")
+    assert.equal(objectAt(result, ["2", "content", "0", "toolCallId"]), "c1")
+    assert.equal(objectAt(result, ["3", "role"]), "tool")
+    assert.equal(objectAt(result, ["3", "content", "0", "toolCallId"]), "c2")
+    assert.deepEqual(objectAt(result, ["4"]), {
+      role: "user",
+      content: [
+        {
+          type: "image",
+          image: "data:image/png;base64,YWFh",
+          mimeType: "image/png",
+        },
+        {
+          type: "image",
+          image: "data:image/png;base64,YmJi",
+          mimeType: "image/png",
+        },
+      ],
+    })
+  })
+
   it("drops previous assistant reasoning while preserving text and tool calls", () => {
     const result = messagesToCC([
       { role: "user", content: "first question" },


### PR DESCRIPTION
## Why

When an assistant turn issues multiple parallel tool calls that include images (for example, reading multiple preview screenshots in Oh My Pi), the generate transport fails with:

```
Error: Tool result is missing for tool call <call_id>.: server_error
```

## Cause

In `src/converters.ts`, `messagesToCC()` iterated through `messages` one by one. For each `toolResult` containing an image, it pushed the `role: "tool"` entry and immediately pushed a `role: "user"` message with the image.

When an assistant turn contains multiple parallel tool calls:

1. `assistant` (`call_1`, `call_2`)
2. `tool` (`call_1` result)
3. `user` (`call_1` image)
4. `tool` (`call_2` result)

The Command Code `/alpha/generate` gateway closes the tool turn once it sees the user message. Because `call_2` result has not arrived yet, the gateway considers `call_2` unanswered and aborts with `server_error`.

## Fix

Batch consecutive `toolResult` messages before emitting image content:

- Group all consecutive `toolResult` messages and emit their `role: "tool"` entries first.
- Collect all images across that batch.
- Emit a single following `role: "user"` message with the accumulated images only after all tool results are in place.

This matches the pattern used by `@earendil-works/pi-ai` and `oh-my-pi`.

## Verification

- `npm run typecheck` — clean
- `npm run test:unit` — 50 tests pass, including new regression test in `tests/test-pure-functions.ts`
- `npm run format:check` — clean
- `git diff --check` — clean
- Tested live against `Qwen/Qwen3.8-Flash` via `/alpha/generate` with parallel image reads; response completed with status 200 without missing tool call errors.