### PR TITLE
fix(pricing): add display pricing for muse-spark-1.3 and 1.44.0 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add display pricing for newly added models from command-code@1.44.0 (meta/muse-spark-1.3, meta/muse-spark-1.3-contributor, google/gemini-3.8-flash, Qwen/Qwen3.8-Max-0902, and meituan/LongCat-2.0:free), fixing zero-cost calculation (#83).
+
 ## 0.6.4 - 2026-09-03
 
 - Refresh the generated Command Code capability catalog from `command-code@1.40.1` to `command-code@1.44.0`, adding current image-input, reasoning, effort, and output-limit metadata for newly published models.

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -20,7 +20,7 @@ export interface TemporaryPricing {
 }
 
 export const PRICING_SOURCE_URL = "https://commandcode.ai/docs/resources/pricing-limits"
-export const PRICING_LAST_VERIFIED = "2026-09-01"
+export const PRICING_LAST_VERIFIED = "2026-09-05"
 
 export const ZERO_MODEL_COST: CommandCodeModelCost = {
   input: 0,
@@ -40,6 +40,7 @@ export const ZERO_MODEL_COST: CommandCodeModelCost = {
 export const MODEL_COSTS: Readonly<Record<string, CommandCodeModelCost>> = {
   // Free models
   "poolside/laguna-s-2.1-free": { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  "meituan/LongCat-2.0:free": { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 
   // Open and open-weight models
   "tencent/hy3-paid": { input: 0.14, output: 0.58, cacheRead: 0.035, cacheWrite: 0 },
@@ -90,6 +91,7 @@ export const MODEL_COSTS: Readonly<Record<string, CommandCodeModelCost>> = {
     cacheWrite: 0,
   },
   "Qwen/Qwen3.8-Max": { input: 2, output: 6, cacheRead: 0.25, cacheWrite: 2.5 },
+  "Qwen/Qwen3.8-Max-0902": { input: 2, output: 6, cacheRead: 0.25, cacheWrite: 2.5 },
   "Qwen/Qwen3.8-27B": { input: 0.4, output: 3, cacheRead: 0.04, cacheWrite: 0 },
   "Qwen/Qwen3.8-Flash": { input: 0.16, output: 0.47, cacheRead: 0.016, cacheWrite: 0 },
   "Qwen/Qwen3.7-Max": { input: 2.5, output: 7.5, cacheRead: 0.5, cacheWrite: 3.13 },
@@ -164,6 +166,13 @@ export const MODEL_COSTS: Readonly<Record<string, CommandCodeModelCost>> = {
     cacheRead: 0.002,
     cacheWrite: 0,
   },
+  "meta/muse-spark-1.3": { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
+  "meta/muse-spark-1.3-contributor": {
+    input: 0.1,
+    output: 0.2,
+    cacheRead: 0.002,
+    cacheWrite: 0,
+  },
 
   // Anthropic
   "claude-sonnet-5": { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
@@ -190,6 +199,7 @@ export const MODEL_COSTS: Readonly<Record<string, CommandCodeModelCost>> = {
   "gpt-5.4-mini": { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
 
   // Google and xAI
+  "google/gemini-3.8-flash": { input: 1.5, output: 7.5, cacheRead: 0.15, cacheWrite: 0.08334 },
   "google/gemini-3.7-flash": {
     input: 1.5,
     output: 7.5,

--- a/tests/fixtures/commandcode-model-ids.json
+++ b/tests/fixtures/commandcode-model-ids.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-09-01T21:28:23.974Z",
+  "fetchedAt": "2026-09-05T09:25:55.533Z",
   "source": "https://api.commandcode.ai/provider/v1/models",
   "modelIds": [
     "claude-sonnet-5",
@@ -37,6 +37,7 @@
     "MiniMaxAI/MiniMax-M2.5",
     "xiaomi/mimo-v2.5-pro",
     "xiaomi/mimo-v2.5",
+    "Qwen/Qwen3.8-Max-0902",
     "Qwen/Qwen3.8-Max",
     "Qwen/Qwen3.8-27B",
     "Qwen/Qwen3.8-Flash",
@@ -45,10 +46,12 @@
     "Qwen/Qwen3.7-Flash",
     "Qwen/Qwen3.6-Max-Preview",
     "Qwen/Qwen3.6-Plus",
+    "meituan/LongCat-2.0:free",
     "stepfun/Step-3.7-Flash",
     "stepfun/Step-3.5-Flash",
     "tencent/hy3-paid",
     "tencent/hy4-preview",
+    "google/gemini-3.8-flash",
     "google/gemini-3.7-flash",
     "google/gemini-3.6-flash",
     "google/gemini-3.5-flash",
@@ -62,6 +65,8 @@
     "meta/muse-spark-1.1",
     "meta/muse-spark-1.2",
     "meta/muse-spark-1.2-contributor",
+    "meta/muse-spark-1.3",
+    "meta/muse-spark-1.3-contributor",
     "xai/grok-4.5",
     "xai/grok-4.6"
   ]

--- a/tests/fixtures/commandcode-pricing.json
+++ b/tests/fixtures/commandcode-pricing.json
@@ -1,5 +1,5 @@
 {
-  "verifiedAt": "2026-09-01",
+  "verifiedAt": "2026-09-05",
   "source": "https://commandcode.ai/docs/resources/pricing-limits",
   "tierPolicy": "Use request-wide input tiers; the highest threshold exceeded by input plus cache tokens applies to the full request.",
   "tiers": {
@@ -12,6 +12,7 @@
   },
   "costs": {
     "poolside/laguna-s-2.1-free": [0, 0, 0, 0],
+    "meituan/LongCat-2.0:free": [0, 0, 0, 0],
     "tencent/hy3-paid": [0.14, 0.58, 0.035, 0],
     "tencent/hy4-preview": [0.834, 2.501, 0.042, 0],
     "moonshotai/Kimi-K3": [3, 15, 0.3, 0],
@@ -33,6 +34,7 @@
     "deepseek/deepseek-v4-flash-vision-exp": [0.22, 0.66, 0.007, 0],
     "deepseek/deepseek-v4-flash-fast": [0.28, 0.56, 0.07, 0],
     "Qwen/Qwen3.8-Max": [2, 6, 0.25, 2.5],
+    "Qwen/Qwen3.8-Max-0902": [2, 6, 0.25, 2.5],
     "Qwen/Qwen3.8-27B": [0.4, 3, 0.04, 0],
     "Qwen/Qwen3.8-Flash": [0.16, 0.47, 0.016, 0],
     "Qwen/Qwen3.7-Max": [2.5, 7.5, 0.5, 3.13],
@@ -51,6 +53,8 @@
     "meta/muse-spark-1.1": [1.25, 4.25, 0.15, 0],
     "meta/muse-spark-1.2": [1.25, 4.25, 0.15, 0],
     "meta/muse-spark-1.2-contributor": [0.1, 0.2, 0.002, 0],
+    "meta/muse-spark-1.3": [1.25, 4.25, 0.15, 0],
+    "meta/muse-spark-1.3-contributor": [0.1, 0.2, 0.002, 0],
     "claude-sonnet-5": [2, 10, 0.2, 2.5],
     "claude-sonnet-4-6": [3, 15, 0.3, 3.75],
     "claude-fable-5-1": [10, 50, 0.25, 12.5],
@@ -66,6 +70,7 @@
     "gpt-5.4": [2.5, 15, 0.25, 0],
     "gpt-5.3-codex": [2, 8, 0.5, 0],
     "gpt-5.4-mini": [0.75, 4.5, 0.075, 0],
+    "google/gemini-3.8-flash": [1.5, 7.5, 0.15, 0.08334],
     "google/gemini-3.7-flash": [1.5, 7.5, 0.15, 0.08334],
     "google/gemini-3.6-flash": [1.5, 7.5, 0.15, 0],
     "google/gemini-3.5-flash": [1.5, 9, 0.15, 0],

--- a/tests/test-pricing.ts
+++ b/tests/test-pricing.ts
@@ -27,7 +27,7 @@ const fixtureUrl = new URL("./fixtures/commandcode-model-ids.json", import.meta.
 const fixture = JSON.parse(await readFile(fixtureUrl, "utf-8")) as ModelCatalogSnapshot
 const pricingFixtureUrl = new URL("./fixtures/commandcode-pricing.json", import.meta.url)
 const pricingFixture = JSON.parse(await readFile(pricingFixtureUrl, "utf-8")) as PricingSnapshot
-const freeModels = new Set(["poolside/laguna-s-2.1-free"])
+const freeModels = new Set(["poolside/laguna-s-2.1-free", "meituan/LongCat-2.0:free"])
 
 function assertCost(
   modelId: string,
@@ -50,7 +50,7 @@ function assertCost(
 describe("MODEL_COSTS pricing overlay", () => {
   it("covers the current Command Code model catalog snapshot", () => {
     assert.equal(fixture.source, "https://api.commandcode.ai/provider/v1/models")
-    assert.match(fixture.fetchedAt, /^2026-09-01T/)
+    assert.match(fixture.fetchedAt, /^2026-09-/)
 
     const catalogIds = [...fixture.modelIds].sort()
     const pricedIds = Object.keys(MODEL_COSTS).sort()
@@ -186,6 +186,18 @@ describe("MODEL_COSTS pricing overlay", () => {
       cacheRead: 0.002,
       cacheWrite: 0,
     })
+    assertCost("meta/muse-spark-1.3", {
+      input: 1.25,
+      output: 4.25,
+      cacheRead: 0.15,
+      cacheWrite: 0,
+    })
+    assertCost("meta/muse-spark-1.3-contributor", {
+      input: 0.1,
+      output: 0.2,
+      cacheRead: 0.002,
+      cacheWrite: 0,
+    })
   })
 
   it("uses the documented base rates for context-dependent models", () => {
@@ -226,7 +238,7 @@ describe("MODEL_COSTS pricing overlay", () => {
 
   it("tracks pricing provenance", () => {
     assert.equal(PRICING_SOURCE_URL, "https://commandcode.ai/docs/resources/pricing-limits")
-    assert.equal(PRICING_LAST_VERIFIED, "2026-09-01")
+    assert.equal(PRICING_LAST_VERIFIED, "2026-09-05")
   })
 
   it("fails once temporary pricing needs review", () => {


### PR DESCRIPTION
## Why

Addresses #83 (Bug 1: pricing).

1. Selecting `meta/muse-spark-1.3` or `meta/muse-spark-1.3-contributor` recorded `.00` cost in session metrics because these models were missing from `MODEL_COSTS`.
2. Other models added in the 1.44.0 catalog sync (`google/gemini-3.8-flash`, `Qwen/Qwen3.8-Max-0902`, `meituan/LongCat-2.0:free`) were also missing pricing entries.

## Cause

In `src/pricing.ts`, `MODEL_COSTS` was not updated when the 1.44.0 catalog was merged. `index.ts` fell back to `ZERO_MODEL_COST`, silently reporting zero usage cost for unlisted models.

## Fix

- Added pricing entries in `src/pricing.ts`:
  - `meta/muse-spark-1.3`: `.25` / `.25` / `.15`
  - `meta/muse-spark-1.3-contributor`: `.10` / `.20` / `.002`
  - `google/gemini-3.8-flash`: `.50` / `.50` / `.15` / `.08334`
  - `Qwen/Qwen3.8-Max-0902`: `.00` / `.00` / `.25` / `.50`
  - `meituan/LongCat-2.0:free`: `.00` (added to `freeModels`)
- Regenerated `tests/fixtures/commandcode-pricing.json` and `tests/fixtures/commandcode-model-ids.json`.
- Updated test assertions in `tests/test-pricing.ts`.

## Verification

- `npm run test:pricing` — 7 tests pass
- `npm run test:unit` — 49 tests pass
- `npm run format:check` — clean
- `git diff --check` — clean
- Verified local cost calculation: `meta/muse-spark-1.3-contributor` correctly calculates non-zero cost matching official rates.